### PR TITLE
Uses `wx.Validator` instead of deprecated `wx.PyValidator`.

### DIFF
--- a/src/ObjectListView3/CellEditor.py
+++ b/src/ObjectListView3/CellEditor.py
@@ -436,12 +436,12 @@ class DateTimeEditor(BaseCellTextEditor):
 #----------------------------------------------------------------------------
 
 
-class NumericValidator(wx.PyValidator):
+class NumericValidator(wx.Validator):
 
     """This validator only accepts numeric keys"""
 
     def __init__(self, acceptableChars="0123456789+-"):
-        wx.PyValidator.__init__(self)
+        wx.Validator.__init__(self)
         self.Bind(wx.EVT_CHAR, self._OnChar)
         self.acceptableChars = acceptableChars
         self.acceptableCodes = [ord(x) for x in self.acceptableChars]


### PR DESCRIPTION
Not tested, but does not throw a warning.