### PR TITLE
update reference to deprecated wx.Python ListItemAttr

### DIFF
--- a/src/ObjectListView3/ObjectListView.py
+++ b/src/ObjectListView3/ObjectListView.py
@@ -949,7 +949,7 @@ class ObjectListView(wx.ListCtrl):
         columnsToResize = []
         for (i, col) in enumerate(self.columns):
             if col.isSpaceFilling:
-                newWidth = freeSpace * col.freeSpaceProportion / totalProportion
+                newWidth = freeSpace * col.freeSpaceProportion // totalProportion
                 boundedWidth = col.CalcBoundedWidth(newWidth)
                 if newWidth == boundedWidth:
                     columnsToResize.append((i, col))
@@ -962,7 +962,7 @@ class ObjectListView(wx.ListCtrl):
         # Finally, give each remaining space filling column a proportion of the
         # free space
         for (i, col) in columnsToResize:
-            newWidth = freeSpace * col.freeSpaceProportion / totalProportion
+            newWidth = freeSpace * col.freeSpaceProportion // totalProportion
             boundedWidth = col.CalcBoundedWidth(newWidth)
             if self.GetColumnWidth(i) != boundedWidth:
                 self.SetColumnWidth(i, boundedWidth)

--- a/src/ObjectListView3/ObjectListView.py
+++ b/src/ObjectListView3/ObjectListView.py
@@ -1777,11 +1777,11 @@ class ObjectListView(wx.ListCtrl):
         # Make sure our empty msg is reasonably positioned
         sz = self.GetClientSize()
         if 'phoenix' in wx.PlatformInfo:
-            self.stEmptyListMsg.SetSize(0, sz.GetHeight() / 3,
+            self.stEmptyListMsg.SetSize(0, sz.GetHeight() // 3,
                                         sz.GetWidth(),
                                         sz.GetHeight())
         else:
-            self.stEmptyListMsg.SetDimensions(0, sz.GetHeight() / 3,
+            self.stEmptyListMsg.SetDimensions(0, sz.GetHeight() // 3,
                                               sz.GetWidth(),
                                               sz.GetHeight())
         # self.stEmptyListMsg.Wrap(sz.GetWidth())

--- a/src/ObjectListView3/ObjectListView.py
+++ b/src/ObjectListView3/ObjectListView.py
@@ -949,7 +949,7 @@ class ObjectListView(wx.ListCtrl):
         columnsToResize = []
         for (i, col) in enumerate(self.columns):
             if col.isSpaceFilling:
-                newWidth = freeSpace * col.freeSpaceProportion // totalProportion
+                newWidth = freeSpace * col.freeSpaceProportion / totalProportion
                 boundedWidth = col.CalcBoundedWidth(newWidth)
                 if newWidth == boundedWidth:
                     columnsToResize.append((i, col))
@@ -962,7 +962,7 @@ class ObjectListView(wx.ListCtrl):
         # Finally, give each remaining space filling column a proportion of the
         # free space
         for (i, col) in columnsToResize:
-            newWidth = freeSpace * col.freeSpaceProportion // totalProportion
+            newWidth = freeSpace * col.freeSpaceProportion / totalProportion
             boundedWidth = col.CalcBoundedWidth(newWidth)
             if self.GetColumnWidth(i) != boundedWidth:
                 self.SetColumnWidth(i, boundedWidth)
@@ -1777,11 +1777,11 @@ class ObjectListView(wx.ListCtrl):
         # Make sure our empty msg is reasonably positioned
         sz = self.GetClientSize()
         if 'phoenix' in wx.PlatformInfo:
-            self.stEmptyListMsg.SetSize(0, sz.GetHeight() // 3,
+            self.stEmptyListMsg.SetSize(0, sz.GetHeight() / 3,
                                         sz.GetWidth(),
                                         sz.GetHeight())
         else:
-            self.stEmptyListMsg.SetDimensions(0, sz.GetHeight() // 3,
+            self.stEmptyListMsg.SetDimensions(0, sz.GetHeight() / 3,
                                               sz.GetWidth(),
                                               sz.GetHeight())
         # self.stEmptyListMsg.Wrap(sz.GetWidth())
@@ -2328,7 +2328,7 @@ class AbstractVirtualObjectListView(ObjectListView):
 
     Due to the vagarities of virtual lists, rowFormatters must operate in a slightly
     different manner for virtual lists. Instead of being passed a ListItem, rowFormatters
-    are passed a ListItemAttr instance. This supports the same formatting methods as a
+    are passed an ItemAttr instance. This supports the same formatting methods as a
     ListItem -- SetBackgroundColour(), SetTextColour(), SetFont() -- but no other ListItem
     methods. Obviously, being a virtual list, the rowFormatter cannot call any SetItem*
     method on the ListView itself.
@@ -2454,10 +2454,10 @@ class AbstractVirtualObjectListView(ObjectListView):
         if not self.useAlternateBackColors and self.rowFormatter is None:
             return None
 
-        # We have to keep a reference to the ListItemAttr or the garbage collector
+        # We have to keep a reference to the ItemAttr or the garbage collector
         # will clear it up immeditately, before the ListCtrl has time to
         # process it.
-        self.listItemAttr = wx.ListItemAttr()
+        self.listItemAttr = wx.ItemAttr()
         self._FormatOneItem(
             self.listItemAttr,
             itemIdx,
@@ -2509,7 +2509,7 @@ class VirtualObjectListView(AbstractVirtualObjectListView):
 
     Due to the vagarities of virtual lists, rowFormatters must operate in a slightly
     different manner for virtual lists. Instead of being passed a ListItem, rowFormatters
-    are passed a ListItemAttr instance. This supports the same formatting methods as a
+    are passed an ItemAttr instance. This supports the same formatting methods as a
     ListItem -- SetBackgroundColour(), SetTextColour(), SetFont() -- but no other ListItem
     methods. Obviously, being a virtual list, the rowFormatter cannot call any SetItem*
     method on the ListView itself.
@@ -3091,7 +3091,7 @@ class GroupListView(FastObjectListView):
         """
         Return the display attributes that should be used for the given row
         """
-        self.listItemAttr = wx.ListItemAttr()
+        self.listItemAttr = wx.ItemAttr()
 
         modelObject = self.innerList[itemIdx]
 
@@ -3099,7 +3099,7 @@ class GroupListView(FastObjectListView):
             return self.listItemAttr
 
         if isinstance(modelObject, ListGroup):
-            # We have to keep a reference to the ListItemAttr or the garbage collector
+            # We have to keep a reference to the ItemAttr or the garbage collector
             # will clear it up immeditately, before the ListCtrl has time to
             # process it.
             if self.groupFont is not None:


### PR DESCRIPTION
wx.ListItemAttr is a deprecated wxPython class that throws warnings. Switched references in ObjectListView to the replacement wx.ItemAttr that has all the same methods.