### PR TITLE
Fix double-click and F2 cell editing

### DIFF
--- a/src/ObjectListView3/ObjectListView.py
+++ b/src/ObjectListView3/ObjectListView.py
@@ -734,7 +734,7 @@ class ObjectListView(wx.ListCtrl):
                 horizDelta = boundsRight - self.GetSize()[0] + (
                     self.GetSize()[0] / 4)
             if wx.Platform == "__WXMSW__":
-                self.ScrollList(horizDelta, 0)
+                self.ScrollList(int(horizDelta), 0)
             else:
                 return None
 
@@ -3828,7 +3828,7 @@ class ColumnDefn(object):
 
         # Try indexed access for dictionary or list like objects
         try:
-            modelObject[munger] = value
+            setattr(modelObject, munger, value)
             return
         except IndexError:
             pass


### PR DESCRIPTION
Potential partial fix for cell editing when double-clicking or using F2